### PR TITLE
Change extensionKind from ui+workspace to workspace

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "url": "https://github.com/r7kamura/vscode-ruby-light.git"
   },
   "extensionKind": [
-    "ui",
     "workspace"
   ],
   "publisher": "r7kamura",


### PR DESCRIPTION
If you install from Marketplace, it will probably be installed as a ui, but in that state it did not work as intended. However, when installed from a vsix file using the code command on WSL, it worked fine.

This change may not fix all the issues, but it should fix some.
