### PR TITLE
Fix README about Expand Selection default shortcut on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,4 +44,4 @@ Select the appropriate ranges when the VSCode's "Expand Selection" command is tr
 This command has the following shortcut keys assigned by default:
 
 - <kbd>Ctrl + Shift + ArrowRight</kbd> on Mac
-- <kbd>Ctrl + Alt + ArrowRight</kbd> on Windows
+- <kbd>Shift + Alt + ArrowRight</kbd> on Windows


### PR DESCRIPTION
Thanks for the nice expansion!
I'll send you what I notice.

The default shortcut in Windows is `Shift+Alt+Right`.
https://code.visualstudio.com/docs/editor/codebasics#_shrinkexpand-selection

`Ctrl + Alt + ArrowRight` don't work.