### PR TITLE
Fix primary extension for Ruby from .arb to .rb

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
           "rb"
         ],
         "extensions": [
+          ".rb",
           ".arb",
           ".builder",
           ".cgi",
@@ -74,7 +75,6 @@
           ".pryrc",
           ".rabl",
           ".rake",
-          ".rb",
           ".rbi",
           ".rbuild",
           ".rbw",


### PR DESCRIPTION
Apparently, VSCode uses the first element of `contributes.languages[].extensions` as the default extension for that language. I was unable to locate the exact documentation for this specification.
