### PR TITLE
Fix: toCorrectable may throw error

### DIFF
--- a/server/src/codeAction.ts
+++ b/server/src/codeAction.ts
@@ -46,5 +46,5 @@ function toCopName(diagnostic: Diagnostic): string {
 }
 
 function toCorrectable(diagnostic: Diagnostic): boolean {
-  return diagnostic.data == null ? false : (diagnostic.data as any).correctable;
+  return (diagnostic.data as any)?.correctable;
 }

--- a/server/src/codeAction.ts
+++ b/server/src/codeAction.ts
@@ -46,5 +46,5 @@ function toCopName(diagnostic: Diagnostic): string {
 }
 
 function toCorrectable(diagnostic: Diagnostic): boolean {
-  return (diagnostic.data as any).correctable;
+  return diagnostic.data == null ? false : (diagnostic.data as any).correctable;
 }


### PR DESCRIPTION
This PR fixes the error that toCorrectable may raise error.
```
[Error - 18:44:15] Request textDocument/codeAction failed.
  Message: Request textDocument/codeAction failed with message: Cannot read properties of undefined (reading 'correctable')
  Code: -32603 
```