### PR TITLE
Migrate server package from CommonJS to ESNext

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,7 @@
 {
   "name": "vscode-ruby-light-server",
   "private": true,
+  "type": "module",
   "dependencies": {
     "diff-match-patch": "^1.0.5",
     "vscode-languageserver": "^7.0.0",

--- a/server/src/bundler.ts
+++ b/server/src/bundler.ts
@@ -1,6 +1,6 @@
 import { existsSync } from "fs";
-import path = require("path");
-import { currentOrAncestorDirectories } from "./directory";
+import * as path from "path";
+import { currentOrAncestorDirectories } from "./directory.js";
 
 export async function inBundlerDirectory(): Promise<boolean> {
   const directories = await currentOrAncestorDirectories();

--- a/server/src/codeAction.ts
+++ b/server/src/codeAction.ts
@@ -7,8 +7,8 @@ import {
   TextDocuments,
 } from "vscode-languageserver";
 import { TextDocument } from "vscode-languageserver-textdocument";
-import { commandIdentifierForAutocorrect } from "./executeCommand";
-import { Settings } from "./settings";
+import { commandIdentifierForAutocorrect } from "./executeCommand.js";
+import { Settings } from "./settings.js";
 
 export function codeActionRequestHandler(
   _settings: Settings,

--- a/server/src/diagnostics.ts
+++ b/server/src/diagnostics.ts
@@ -14,8 +14,8 @@ import {
   RuboCopOffense,
   RuboCopSeverity,
   inRuboCopDirectory,
-} from "./rubocop";
-import { Settings } from "./settings";
+} from "./rubocop.js";
+import { Settings } from "./settings.js";
 
 export async function diagnosticsRequestHandler(
   settings: Settings,

--- a/server/src/directory.ts
+++ b/server/src/directory.ts
@@ -1,5 +1,5 @@
 import { readlink } from "fs/promises";
-import path = require("path");
+import * as path from "path";
 
 export async function currentOrAncestorDirectories(): Promise<Array<string>> {
   const directories = [];

--- a/server/src/documentFormatting.ts
+++ b/server/src/documentFormatting.ts
@@ -6,9 +6,9 @@ import {
 } from "vscode-languageserver";
 import { TextDocument } from "vscode-languageserver-textdocument";
 import { URI } from "vscode-uri";
-import { inRuboCopDirectory, runRuboCopAutocorrect } from "./rubocop";
-import { Settings } from "./settings";
-import { fromDiff } from "./textEdit";
+import { inRuboCopDirectory, runRuboCopAutocorrect } from "./rubocop.js";
+import { Settings } from "./settings.js";
+import { fromDiff } from "./textEdit.js";
 
 export async function documentFormattingRequestHandler(
   settings: Settings,

--- a/server/src/documentHighlight.ts
+++ b/server/src/documentHighlight.ts
@@ -5,11 +5,11 @@ import {
   TextDocuments,
 } from "vscode-languageserver";
 import { TextDocument } from "vscode-languageserver-textdocument";
-import Parser = require("web-tree-sitter");
-import { currentNode, toRange } from "./node";
-import { parse } from "./parser";
-import Position from "./Position";
-import { Settings } from "./settings";
+import * as Parser from "web-tree-sitter";
+import { parse } from "./parser.js";
+import { currentNode, toRange } from "./node.js";
+import Position from "./Position.js";
+import { Settings } from "./settings.js";
 
 export function documentHighlightRequestHandler(
   settings: Settings,

--- a/server/src/documentRangeFormatting.ts
+++ b/server/src/documentRangeFormatting.ts
@@ -6,9 +6,9 @@ import {
 } from "vscode-languageserver";
 import { TextDocument } from "vscode-languageserver-textdocument";
 import { URI } from "vscode-uri";
-import { inRuboCopDirectory, runRuboCopAutocorrect } from "./rubocop";
-import { Settings } from "./settings";
-import { fromDiff } from "./textEdit";
+import { inRuboCopDirectory, runRuboCopAutocorrect } from "./rubocop.js";
+import { Settings } from "./settings.js";
+import { fromDiff } from "./textEdit.js";
 
 export async function documentRangeFormattingRequestHandler(
   settings: Settings,

--- a/server/src/documentSymbol.ts
+++ b/server/src/documentSymbol.ts
@@ -5,10 +5,10 @@ import {
   TextDocuments,
 } from "vscode-languageserver";
 import { TextDocument } from "vscode-languageserver-textdocument";
-import Parser = require("web-tree-sitter");
-import { selfAndAncestors, toRange } from "./node";
-import { parse } from "./parser";
-import { Settings } from "./settings";
+import * as Parser from "web-tree-sitter";
+import { selfAndAncestors, toRange } from "./node.js";
+import { parse } from "./parser.js";
+import { Settings } from "./settings.js";
 
 export function documentSymbolRequestHandler(
   settings: Settings,

--- a/server/src/executeCommand.ts
+++ b/server/src/executeCommand.ts
@@ -6,9 +6,9 @@ import {
 } from "vscode-languageserver";
 import { TextDocument } from "vscode-languageserver-textdocument";
 import { URI } from "vscode-uri";
-import { runRuboCopAutocorrect } from "./rubocop";
-import { Settings } from "./settings";
-import { fromDiff } from "./textEdit";
+import { runRuboCopAutocorrect } from "./rubocop.js";
+import { Settings } from "./settings.js";
+import { fromDiff } from "./textEdit.js";
 
 export const commandIdentifierForAutocorrect = "RubyLight.Autocorrect";
 

--- a/server/src/node.ts
+++ b/server/src/node.ts
@@ -1,6 +1,6 @@
 import { Range } from "vscode-languageserver";
-import Parser = require("web-tree-sitter");
-import Position from "./Position";
+import * as Parser from "web-tree-sitter";
+import Position from "./Position.js";
 
 export function ancestors(node: Parser.SyntaxNode): Parser.SyntaxNode[] {
   const ancestors: Parser.SyntaxNode[] = [];

--- a/server/src/rubocop.ts
+++ b/server/src/rubocop.ts
@@ -1,7 +1,7 @@
 import { existsSync } from "fs";
-import path = require("path");
-import { currentOrAncestorDirectories } from "./directory";
-import { runCommandWithOrWithoutBundler } from "./spawn";
+import * as path from "path";
+import { currentOrAncestorDirectories } from "./directory.js";
+import { runCommandWithOrWithoutBundler } from "./spawn.js";
 
 export async function inRuboCopDirectory(): Promise<boolean> {
   const directories = await currentOrAncestorDirectories();

--- a/server/src/selectionRanges.ts
+++ b/server/src/selectionRanges.ts
@@ -5,11 +5,11 @@ import {
   TextDocuments,
 } from "vscode-languageserver";
 import { TextDocument } from "vscode-languageserver-textdocument";
-import Parser = require("web-tree-sitter");
-import { currentNode, selfAndAncestors, toRange } from "./node";
-import { parse } from "./parser";
-import Position from "./Position";
-import { Settings } from "./settings";
+import * as Parser from "web-tree-sitter";
+import { currentNode, selfAndAncestors, toRange } from "./node.js";
+import { parse } from "./parser.js";
+import Position from "./Position.js";
+import { Settings } from "./settings.js";
 
 export function selectionRangesRequestHandler(
   settings: Settings,

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -5,24 +5,24 @@ import {
   ProposedFeatures,
   TextDocuments,
   TextDocumentSyncKind,
-} from "vscode-languageserver/node";
+} from "vscode-languageserver/node.js";
 import { TextDocument } from "vscode-languageserver-textdocument";
-import { initializeParser } from "./parser";
-import { documentHighlightRequestHandler } from "./documentHighlight";
-import { selectionRangesRequestHandler } from "./selectionRanges";
-import { documentSymbolRequestHandler } from "./documentSymbol";
-import { codeActionRequestHandler } from "./codeAction";
-import { documentFormattingRequestHandler } from "./documentFormatting";
+import { initializeParser } from "./parser.js";
+import { documentHighlightRequestHandler } from "./documentHighlight.js";
+import { selectionRangesRequestHandler } from "./selectionRanges.js";
+import { documentSymbolRequestHandler } from "./documentSymbol.js";
+import { codeActionRequestHandler } from "./codeAction.js";
+import { documentFormattingRequestHandler } from "./documentFormatting.js";
 import {
   commandIdentifiers,
   executeCommandRequestHandler,
-} from "./executeCommand";
-import { defaultSettings, getSettings, Settings } from "./settings";
+} from "./executeCommand.js";
+import { defaultSettings, getSettings, Settings } from "./settings.js";
 import {
   diagnosticsRequestHandler,
   refreshAllDocumentsDiagnostics,
-} from "./diagnostics";
-import { documentRangeFormattingRequestHandler } from "./documentRangeFormatting";
+} from "./diagnostics.js";
+import { documentRangeFormattingRequestHandler } from "./documentRangeFormatting.js";
 
 const connection = createConnection(ProposedFeatures.all);
 

--- a/server/src/spawn.ts
+++ b/server/src/spawn.ts
@@ -1,5 +1,5 @@
 import { spawn } from "child_process";
-import { inBundlerDirectory } from "./bundler";
+import { inBundlerDirectory } from "./bundler.js";
 
 export async function runCommandWithOrWithoutBundler(
   command: string,

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "es2020",
     "lib": ["es2020"],
-    "module": "commonjs",
+    "module": "ESNext",
     "moduleResolution": "node",
     "sourceMap": true,
     "strict": true,


### PR DESCRIPTION
For using `@ruby/prism` via static import in the future.
